### PR TITLE
Admin Photo Panel: Approve/Decline Photos

### DIFF
--- a/app/admin/photo.rb
+++ b/app/admin/photo.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register Photo do
   filter :created_at
 
-  scope :pending, default: true
+  scope :all
+  scope :pending
   scope :approved
   scope :declined
 
@@ -23,21 +24,43 @@ ActiveAdmin.register Photo do
     redirect_to admin_photos_path
   end
 
+  member_action :approve, method: :put do
+    photo = Photo.find params[:id]
+    authorize! :approve, Photo
+    photo.approve!
+    redirect_to [:admin, :photos]
+  end
+
+  member_action :decline, method: :put do
+    photo = Photo.find params[:id]
+    authorize! :decline, Photo
+    photo.decline!
+    redirect_to [:admin, :photos]
+  end
+
   index title: 'Photos', download_links: false do
     selectable_column
 
-    column :user do |r|
-      link_to r.user.name, [:admin, r.user]
+    column :user do |photo|
+      link_to photo.user.name, [:admin, photo.user]
     end
 
-    column :photo do |r|
-      link_to r.image.url, class: :fancybox_popups do
-        image_tag r.image.url(:medium)
+    column :photo do |photo|
+      link_to photo.image.url, class: :fancybox_popups do
+        image_tag photo.image.url(:medium)
       end
     end
 
     column :photo_nudity_status do |photo|
       photo.nudity
+    end
+
+    column 'Approve Status' do |photo|
+      render 'admin/photo/approve_status', photo: photo
+    end
+
+    column 'Approve' do |photo|
+      render 'admin/photo/approve_actions', photo: photo
     end
 
     default_actions

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,6 +12,7 @@ class ProfilesController < BaseController
   def load_profile
     @user = User.find(params[:user_id])
     @profile = @user.profile
+    @profile.safe_for_user = current_user
   end
 
   def require_filled_profile

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,8 @@ class UsersController < BaseController
   end
 
   def setup_profiles
-    @profiles = @profile.near_me(@search.location, @search.max_distance)
+    @profiles = @profile
+        .near_me(@search.location, @search.max_distance)
         .preload(:user).search_hstore(@search.query)
     @profile_sections = Profile.searchable_params
   end

--- a/app/jobs/validate_nudity_job.rb
+++ b/app/jobs/validate_nudity_job.rb
@@ -1,4 +1,12 @@
 class ValidateNudityJob < Struct.new(:photo_id)
+  def self.create_delayed_job(*args)
+    if Payperdate::Application.config.background_workers_envs.include? Rails.env
+      Delayed::Job.enqueue ValidateNudityJob.new(*args)
+    else
+      ValidateNudityJob.new(*args).perform
+    end
+  end
+
   def perform
     Photo.find(photo_id).validate_nudity!
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -2,9 +2,31 @@ class NotificationMailer < ActionMailer::Base
   default from: 'support@payperdate.com'
 
   def photo_was_declined(user_id, photo_url)
+    deliver_email(:deliver_photo_was_declined, user_id, photo_url)
+  end
+
+  private
+  
+  def deliver_email(what, *args)
+    if Payperdate::Application.config.background_workers_envs.include? Rails.env 
+      send_background what, *args
+    else
+      send_now what, *args
+    end
+  end
+
+  def deliver_photo_was_declined(user_id, photo_url)
     @user = User.find(user_id)
     @photo_url = photo_url
-    mail(to: user.email, subject: 'Your photo has been declined')
+    mail(to: @user.email, subject: 'Your photo has been declined')
+  end
+
+  def send_background(what, *args)
+    delay.send(what, *args)
+  end
+
+  def send_now(what, *args)
+    send(what, *args).deliver
   end
 
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -43,7 +43,7 @@ class Profile < ActiveRecord::Base
       { section: 'optional_info', key: 'drinker', type: :select, subtype: 'me_drinker' }
     ]
   }
-  
+
   MAX_DISTANCE = 9999999
 
   belongs_to :user
@@ -148,8 +148,12 @@ class Profile < ActiveRecord::Base
       date_preferences && optional_info
   end
 
-  def avatar_url(version=:avatar)
-    (avatar || Avatar.new).image_url(version)
+  def avatar_url(version=:avatar, public_avatar=true)
+    if public_avatar
+      (avatar && avatar.public_photo || Avatar.new).image_url(version)
+    else
+      (avatar || Avatar.new).image_url(version)
+    end
   end
 
   def distance_do_care?

--- a/app/views/admin/photo/_approve_actions.html.erb
+++ b/app/views/admin/photo/_approve_actions.html.erb
@@ -1,0 +1,6 @@
+<% unless photo.approved? %>	
+	<%= link_to 'Approve', approve_admin_photo_path(photo), method: :put, class: 'button' %>
+<% end %>
+<% unless photo.declined? %>
+	<%= link_to 'Decline', decline_admin_photo_path(photo), method: :put, class: 'button' %>
+<% end %>

--- a/app/views/admin/photo/_approve_status.html.erb
+++ b/app/views/admin/photo/_approve_status.html.erb
@@ -1,0 +1,7 @@
+<% if photo.approved? %>
+  <strong>Approved</strong>
+<% elsif photo.declined? %>
+  <strong>Declined</strong>
+<% else %>
+  <strong>Pending</strong>
+<% end %>

--- a/app/views/avatars/_avatar.html.haml
+++ b/app/views/avatars/_avatar.html.haml
@@ -1,4 +1,4 @@
 #avatar
-  = image_tag  profile.avatar_url
+  = image_tag  profile.avatar_url(:avatar, !can?(:manage, profile.avatar))
   - if profile.avatar && can?(:manage, profile.avatar)
     = link_to 'Remove avatar', profile.avatar, method: :delete, data: {confirm: 'Sure?'}, remote: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module Payperdate
 
     config.assets.precompile += ['rails_admin/rails_admin.css', 'rails_admin/rails_admin.js']
     config.assets.precompile += %w(*.png *.jpg *.jpeg *.gif)
+
+    config.background_workers_envs = [:production]
   end
 end

--- a/lib/payperdate/nudity/impl/nude_impl.rb
+++ b/lib/payperdate/nudity/impl/nude_impl.rb
@@ -3,6 +3,9 @@ require 'nude'
 module NudityDetectorService
   class NudeImpl
     def nude?(image_path)
+      if Rails.env.development?
+        image_path = "public/#{image_path}"
+      end
       Nude.nude?(image_path)
     end
   end

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -12,14 +12,19 @@ desc 'Setup sample data'
 task setup_sample_data: :environment do
   raise 'do not run this task in production' if Rails.env.production?
 
+  puts 'Cleaning delayed jobs..'
   Delayed::Job.delete_all
 
+  puts 'Cleaning users..'
   User.delete_all
+  puts 'Cleaning admin users..'
   AdminUser.delete_all
+  puts 'Cleaning authentitications..'
   Authentitication.delete_all
-  Album.destroy_all
+  puts 'Cleaning albums..'
+  Album.delete_all
 
-  puts 'Setting up admin'
+  puts 'Setting up master admin..'
 
   a = AdminUser.new
   2.times do
@@ -30,7 +35,7 @@ task setup_sample_data: :environment do
   end
   # end
 
-  puts 'Setting up users'
+  puts 'Setting up users..'
 
   create_users
 


### PR DESCRIPTION
Heroku: http://payperdate-22-pictures-vali-ip.herokuapp.com/
- [x] Pictures validation process is not working intuitively. We need to add buttons "Approve" and "Decline" (not "edit" and then set 1 or 2). 
- [x] Send a message to user if his picture was declined.
- [x] List of all photos with Approve/Decline status.
- [x] Don't show declined photos to other users.

In order to have ability to approve/decline uploaded photos,
As admin with permissions to approve,
I can got to the Photo page,
See all photos with Approve/Decline status as separate column
And can approve/decline by clicking correspond to my action button for each Photo row
Can filter photos by approve status: pending, approve, declined.
