### PR TITLE
#32: Ability to Delete inappropriate users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -33,6 +33,19 @@ ActiveAdmin.register User do
     redirect_to [:admin, :users]
   end
 
+  member_action :delete, method: :delete do
+    user = User.find(params[:id])
+    authorize! :delete, User
+    user.delete_account!
+    redirect_to [:admin, :users]
+  end
+
+  batch_action :delete_account do |selection|
+    authorize! :delete, User
+    User.find(selection).each { |user| user.delete_account! }
+    redirect_to [:admin, :users]
+  end
+
   index do
     selectable_column
     column :name

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -23,6 +23,13 @@ class ProfilesController < BaseController
     end
   end
 
+  def check_if_user_is_blocked
+    if @profile.user.blocked?
+      flash[:alert] = t 'users.errors.user_blocked'
+      redirect_to root_path
+    end
+  end
+
   def require_filled_profile
     unless @profile.filled?
       flash[:alert] = t 'users.errors.foreign_user_has_no_profile'

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,6 +12,11 @@ class NotificationMailer < ActionMailer::Base
     deliver_mail mail(to: @user.email, subject: 'Your account has been blocked')
   end
 
+  def user_was_deleted(email, name)
+    @name = name
+    deliver_mail mail(to: email, subject: 'Your account has been deleted')
+  end
+
   private
 
   def deliver_mail(mail)

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -16,6 +16,7 @@ class AdminAbility
         if admin.get_permissions[:permission_customer_care]
           can :read, User
           can :block, User
+          can :delete, User
         end
       end
       can :read, ActiveAdmin::Page, :name => "Dashboard"

--- a/app/views/admin/user/_customer_care_actions.html.erb
+++ b/app/views/admin/user/_customer_care_actions.html.erb
@@ -1,5 +1,8 @@
 <% if user.blocked? %>
 	<%= link_to 'Unblock', send("unblock_admin_#{resource}_path", user), method: :put, class: :button %>
+	<br/>
 <% else %>
 	<%= link_to 'Block', send("block_admin_#{resource}_path", user), method: :put, class: :button %>
+	<br/>
 <% end %>
+<%= link_to 'Delete', send("delete_admin_#{resource}_path", user), method: :delete, class: :button %>

--- a/app/views/notification_mailer/user_was_deleted.html.erb
+++ b/app/views/notification_mailer/user_was_deleted.html.erb
@@ -1,0 +1,7 @@
+<p>
+  Hi, <%= @name %>!
+</p>
+
+<p>
+  We are sorry, but your account was deleted.
+</p>

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -196,7 +196,7 @@ rias:
   personal_preferences_partners_sex: M
   personal_preferences_relationship: D
   personal_preferences_want_relationship: D
-  date_preferences_accepted_distance: 
+  date_preferences_accepted_distance:
   date_preferences_accepted_distance_do_care: 'false'
   date_preferences_smoker: N
   date_preferences_drinker: N
@@ -205,7 +205,7 @@ rias:
   optional_info_education: B
   optional_info_occupation: Work and study
   optional_info_annual_income: ''
-  optional_info_net_worth: 
+  optional_info_net_worth:
   optional_info_height: 165
   optional_info_body_type: S
   optional_info_religion: O

--- a/test/integration/delete_inappropriate_users_test.rb
+++ b/test/integration/delete_inappropriate_users_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class LoginIfNotDeletedTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  fixtures :users, :profiles
+
+  def setup
+    reset_session!
+    visit "/users/login"
+    page.fill_in :user_email, with: users(:martin).email
+    page.fill_in :user_password, with: 'password'
+    page.click_button 'Sign in'
+  end
+
+  test 'login should be ok' do
+    refute page.has_content? 'Invalid email or password.'
+  end
+end
+
+class LoginIfDeletedTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  fixtures :users, :profiles
+
+  def setup
+    reset_session!
+    users(:martin).delete_account!
+    visit "/users/login"
+    page.fill_in :user_email, with: users(:martin).email
+    page.fill_in :user_password, with: 'password'
+    page.click_button 'Sign in'
+  end
+
+  test 'login should result in error' do
+    assert page.has_content? 'Invalid email or password.'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,3 +18,4 @@ end
 class ActionController::TestCase
   include Devise::TestHelpers
 end
+


### PR DESCRIPTION
As Admin
Given permission "Customer Care"
Or Master Admin

I can block selected users by checking them and click/select action delete,
Or can delete single user by clicking on button delete on the same row with the user.

All deleted users notified about that by email.

All deleted users should not be able to access site,
and should not be searchable or viewable by others users.

Heroku: http://payperdate-32-ability-to-de-ip.herokuapp.com/
- [x] Add delete action for user in user list.
- [x] Add ability for Customer Care to delete users.
- [x] Notify user about account deletion.
- [x] Test permission for Customer Care to delete users.
- [x] Test deleted user is unable to sign in.
- [x] Test deleted user received notification.

http://www.skadate.com/demo/admin/profile_list.php?sex=1

"Administrators should be able to delete appropriate users
Page to list the users based on search or based on abuse flag against the user and possibility to delete them."

Notification User by email about status.
Admin Role: Customer Care 
