### PR TITLE
edit gifts on admin panel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog', '~> 1.3.1'
 
+gem 'state_machine'
 
 # Assets
 

--- a/app/admin/gift.rb
+++ b/app/admin/gift.rb
@@ -1,0 +1,62 @@
+ActiveAdmin.register Gift do
+  Gift.state_machines[:state].states.each do |state|
+    scope state.name
+  end
+
+  batch_action :disable do |selection|
+    authorize! :disable, Gift
+    Gift.find(selection).each do |gift|
+      gift.disable!
+    end
+    redirect_to admin_gifts_path
+  end
+
+  batch_action :enable do |selection|
+    authorize! :enable, Gift
+    Gift.find(selection).each do |gift|
+      gift.enable!
+    end
+    redirect_to admin_gifts_path
+  end
+
+  member_action :enable, method: :put do
+    gift = Gift.find(params[:id])
+    authorize! :enable, Gift
+    gift.enable
+    redirect_to [:admin, :gifts]
+  end
+
+  member_action :disable, method: :put do
+    gift = Gift.find(params[:id])
+    authorize! :disable, Gift
+    gift.disable
+    redirect_to [:admin, :gifts]
+  end
+
+  index title: 'Gifts', download_links: false do
+    selectable_column
+
+    column :gift do |gift|
+      link_to gift.image.url, class: :fancybox_popups do
+        image_tag gift.image.url(:medium)
+      end
+    end
+
+    column :state do |gift|
+      gift.state
+    end
+
+    column 'State actions' do |photo|
+      render 'admin/gift/state_actions', gift: photo
+    end
+
+    default_actions
+  end
+
+  form do |f|
+    f.inputs 'Gift' do
+      f.input :image, hint: f.template.image_tag(f.object.image.url(:medium))
+    end
+    f.actions
+  end
+end

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -18,6 +18,9 @@ class AdminAbility
           can :block, User
           can :delete, User
         end
+        if admin.get_permissions[:permission_gifts_and_winks]
+          can :manage, Gift
+        end
       end
 
       can :read, ActiveAdmin::Page, name: 'Dashboard'

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,5 +1,5 @@
 class AdminUser < ActiveRecord::Base
-  PERMISSIONS = [:permission_approver, :permission_customer_care]
+  PERMISSIONS = [:permission_approver, :permission_customer_care, :permission_gifts_and_winks]
 
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable

--- a/app/models/gift.rb
+++ b/app/models/gift.rb
@@ -1,0 +1,23 @@
+class Gift < ActiveRecord::Base
+  validates :image, presence: true, file_size: { maximum: 5.megabytes.to_i }
+
+  mount_uploader :image, GiftUploader
+
+  state_machine :state, initial: :enabled do
+    event :enable do
+      transition all => :enabled
+    end
+
+    event :disable do
+      transition all => :disabled
+    end
+  end
+
+  def self.all_states
+    state_machines[:state].states
+  end
+
+  all_states.each do |state|
+    scope state.name, -> { where(state: state.name) }
+  end
+end

--- a/app/uploaders/gift_uploader.rb
+++ b/app/uploaders/gift_uploader.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+
+class GiftUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/gifts/#{mounted_as}/#{model.id}"
+  end
+
+  version :medium do
+    process resize_to_fit: [100, 100]
+  end
+
+  version :thumb do
+    process resize_to_fill: [50, 50]
+  end
+
+  def default_url
+    '/images/fallback/' + [version_name, 'default.png'].compact.join('_')
+  end
+
+  # Process files as they are uploaded:
+  # process :scale => [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  def extension_white_list
+    %w(jpg jpeg gif png)
+  end
+end

--- a/app/views/admin/gift/_state_actions.html.erb
+++ b/app/views/admin/gift/_state_actions.html.erb
@@ -1,0 +1,8 @@
+<% unless gift.enabled? %>
+    <%= link_to 'Enable', send('enable_admin_gift_path', gift), method: :put, class: :button %>
+    <br/>
+<% end %>
+<% unless gift.disabled? %>
+    <%= link_to 'Disable', send('disable_admin_gift_path', gift), method: :put, class: :button %>
+    <br/>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
       no_permissions: 'No permissions'
       permission_approver: 'Approver (access only to Picture and Profile approval/rejection)'
       permission_customer_care: 'Customer Care (delete users, respond to user questions, etc)'
+      permission_gifts_and_winks: 'Gifts and Winks (manage gifts and winks)'
     photo:
       declined:
         reason:

--- a/db/migrate/20130730133258_create_gifts.rb
+++ b/db/migrate/20130730133258_create_gifts.rb
@@ -1,0 +1,10 @@
+class CreateGifts < ActiveRecord::Migration
+  def change
+    create_table :gifts do |t|
+      t.string :image, null: false
+      t.string :state
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20130731090749_add_gits_and_winks_permission_to_admin_user.rb
+++ b/db/migrate/20130731090749_add_gits_and_winks_permission_to_admin_user.rb
@@ -1,0 +1,5 @@
+class AddGitsAndWinksPermissionToAdminUser < ActiveRecord::Migration
+  def change
+    add_column :admin_users, :permission_gifts_and_winks, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130724165534) do
+ActiveRecord::Schema.define(version: 20130731090749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,12 +28,12 @@ ActiveRecord::Schema.define(version: 20130724165534) do
   end
 
   create_table "admin_users", force: true do |t|
-    t.string   "email",                    default: "", null: false
-    t.string   "encrypted_password",       default: "", null: false
+    t.string   "email",                      default: "", null: false
+    t.string   "encrypted_password",         default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",            default: 0
+    t.integer  "sign_in_count",              default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20130724165534) do
     t.boolean  "master"
     t.boolean  "permission_approver"
     t.boolean  "permission_customer_care"
+    t.boolean  "permission_gifts_and_winks"
   end
 
   add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
@@ -86,6 +87,13 @@ ActiveRecord::Schema.define(version: 20130724165534) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
+  create_table "gifts", force: true do |t|
+    t.string   "image",      null: false
+    t.string   "state"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "photos", force: true do |t|
     t.integer  "album_id",                          null: false

--- a/test/controllers/admin/gifts_controller_test.rb
+++ b/test/controllers/admin/gifts_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class Admin::GiftsControllerTest < ActionController::TestCase
+  fixtures :admin_users
+
+  def setup
+    @controller = ::Admin::GiftsController.new
+  end
+
+  test 'master admin should have access to gifts' do
+    sign_in admin_users(:admin)
+
+    get :index
+    assert_response :success
+  end
+
+  test 'non master admin should not have access to gifts' do
+    sign_in admin_users(:john)
+
+    get :index
+    assert_redirected_to admin_root_path
+    assert_equal 'You are not authorized to perform this action.', flash[:error]
+  end
+
+  test 'non master admin should have access to gifts if allowed to manage gifts and winks' do
+    sign_in admin_users(:anthony)
+
+    get :index
+    assert_response :success
+  end
+end

--- a/test/fixtures/admin_users.yml
+++ b/test/fixtures/admin_users.yml
@@ -5,6 +5,7 @@ admin:
   master: true
   permission_approver: false
   permission_customer_care: false
+  permission_gifts_and_winks: false
 
 # Non master admin user
 john:
@@ -13,6 +14,7 @@ john:
   master: false
   permission_approver: false
   permission_customer_care: false
+  permission_gifts_and_winks: false
 
 # Approver
 james:
@@ -21,6 +23,7 @@ james:
   master: false
   permission_approver: true
   permission_customer_care: false
+  permission_gifts_and_winks: false
 
 # Customer Care
 bill:
@@ -29,3 +32,13 @@ bill:
   master: false
   permission_approver: false
   permission_customer_care: true
+  permission_gifts_and_winks: false
+
+# Gifts and Winks
+anthony:
+  email: anthony.stone@example.com
+  encrypted_password: "$2a$10$C8mEde58Tg/X.n4XGqvTQOCV5/RM8NIjTAb3zZUbDS2Xn.7bZnuu2" #password
+  master: false
+  permission_approver: false
+  permission_customer_care: false
+  permission_gifts_and_winks: true

--- a/test/models/gift_test.rb
+++ b/test/models/gift_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class GiftTest < ActiveSupport::TestCase
+  def test_create
+    gift = Gift.create! image: create_tmp_image
+    assert_predicate gift, :enabled?
+  end
+
+  def test_disable
+    gift = Gift.create! image: create_tmp_image
+    gift.disable
+    assert_predicate gift, :disabled?
+  end
+
+  def test_enable
+    gift = Gift.create! image: create_tmp_image
+    gift.enable
+    assert_predicate gift, :enabled?
+  end
+end


### PR DESCRIPTION
Admin is able to add/edit/remove gifts on admin panel (name, picture, cost).
To do this sub-admin has to have permission - role (gifts and winks).

Each sub-admin might have several roles. Muster admin has full access to everything - all roles.
