### PR TITLE
Member management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'mandrill-api', github: 'XsErG/mandrill-api', require: 'mandrill'
 
 gem 'obscenity' # profanity filter, used only to help approver
 
+gem 'obscenity' # profanity filter, used only to help approver
+
 
 # Background jobs
 gem 'delayed_job_active_record', '>= 4.0.0.beta1'

--- a/app/admin/profile.rb
+++ b/app/admin/profile.rb
@@ -4,145 +4,8 @@ ActiveAdmin.register Profile do
 
   show title: -> p { p.name } do |profile|
     extend ProfilesHelper
-    unless profile.reviewed?
-      div class: 'profile-grid' do
-        div class: 'profile-col-1-3' do
-          prev_profile = profile.prev_queued_for_approval
-          prev_title = profile.prev_queued_for_approval.nil? ? 'List' : 'Next'
-          next_profile = profile.next_queued_for_approval
-          next_title = profile.next_queued_for_approval.nil? ? 'List' : 'Prev'
-          span do
-            link_to next_title, admin_profile_path(next_profile), class: :button
-          end
-          unless prev_profile.nil? && next_profile.nil?
-            span do
-              link_to prev_title, admin_profile_path(prev_profile), class: :button
-            end
-          end
-        end
-      end
-      br
-    end
-    div class: 'profile-grid' do
-      div class: 'profile-col-1-2' do
-        h3 do
-          span do
-            'Main Profile Info'
-          end
-          if profile.profane?
-            span 'Profane!', class: 'profile-label-danger'
-          end
-        end
-        panel 'Profile Info' do
-          attributes_table_for profile do
-            row :auto_user
-            select_row :personal_preferences_sex, 'sex'
-            select_row :personal_preferences_partners_sex, 'sex'
-            row :optional_info_age do
-              span profile.optional_info_age
-              em '(here should be birthday, planned in #53)'
-            end
-            select_row :personal_preferences_relationship, 'relationship'
-            select_row :personal_preferences_want_relationship, 'want_relationship'
-          end
-        end
-        panel 'Essays' do
-          form_for profile, url: admin_profile_path(profile) do |f|
-            strong 'Marked words are possible profane' if profile.profane?
-            span do
-              link_to 'Edit', '#', class: 'profile-inline-edit-activate'
-            end
-            attributes_table_for profile do
-              row_with_profanity :general_info_tagline
-              row :general_info_tagline_edit, class: 'profile-hide profile-inline-edit' do
-                f.text_field :general_info_tagline, class: 'profile-hide profile-inline-edit'
-              end
-              row_with_profanity :general_info_description
-              row :general_info_description_edit, class: 'profile-hide profile-inline-edit' do
-                f.text_area :general_info_description, class: 'profile-hide profile-inline-edit',
-                            rows: 5
-              end
-              row_with_profanity :date_preferences_description
-              row :date_preferences_description_edit, class: 'profile-hide profile-inline-edit' do
-                f.text_area :date_preferences_description, class: 'profile-hide profile-inline-edit',
-                            rows: 5
-              end
-              row 'Submit', class: 'profile-hide profile-inline-edit' do
-                f.submit class: 'button'
-              end
-            end
-          end
-        end
-        panel 'Physical Features' do
-          attributes_table_for profile do
-            row :optional_info_height do
-              "#{profile.optional_info_height} cm" unless profile.optional_info_height.blank?
-            end
-            select_row :optional_info_body_type, 'body_type'
-            select_row :optional_info_hair_color, 'hair_color'
-            select_row :optional_info_eye_color, 'eye_color'
-          end
-        end
-        panel 'Matches' do
-          attributes_table_for profile do
-            row :date_preferences_accepted_distance_do_care
-            if profile.distance_do_care?
-              row :date_preferences_accepted_distance do
-                "#{profile.date_preferences_accepted_distance} miles"
-              end
-            end
-            select_row :date_preferences_smoker, 'smoker'
-            select_row :date_preferences_drinker, 'drinker'
-          end
-        end
-        panel 'Social' do
-          attributes_table_for profile do
-            row :optional_info_occupation
-            row :optional_info_annual_income do
-              unless profile.optional_info_annual_income.blank?
-                "#{profile.optional_info_annual_income}$ per year"
-              end
-            end
-            row :optional_info_net_worth do
-              unless profile.optional_info_net_worth.blank?
-                "#{profile.optional_info_net_worth}$"
-              end
-            end
-          end
-        end
-      end
-      div class: 'profile-col-1-3' do
-        h3 'Profile Summary'
-        panel 'Summary' do
-          div class: 'profile-grid' do
-            div class: 'profile-col-2-3' do
-              strong profile.auto_user.name
-              span "#{profile.optional_info_age || '??'} y/o"
-              br
-              div 'from'
-              strong profile.full_address
-              br
-              div 'Status:'
-              strong 'Active' unless profile.auto_user.blocked?
-              strong 'Suspended' if profile.auto_user.blocked?
-              br
-              div 'Last activity:'
-              activity = profile.auto_user.activities.last
-              if activity
-                strong "#{distance_of_time_in_words activity.created_at, Time.now} ago"
-              else
-                span '-'
-              end
-              br
-              span "Join date: #{profile.created_at.to_date}"
-            end
-            div class: 'profile-col-1-3' do
-              render 'profile/avatar', profile: profile
-            end
-          end
-        end
-      end
-    end
+    render 'admin/profile/approval_queue_navigation'
+    render 'admin/profile/profile'
   end
 
   member_action :approve, method: :put do
@@ -174,10 +37,14 @@ ActiveAdmin.register Profile do
           link_to 'Block', block_admin_user_path(profile.auto_user), method: :put, class: :button
         end
       end
+      span do
+        link_to 'Delete', delete_admin_user_path(profile.auto_user), method: :delete, class: :button
+      end
     end
   end
 
   index as: :block do |profile|
+    extend ProfilesHelper
     div for: profile do
       br
       h2 do
@@ -190,8 +57,14 @@ ActiveAdmin.register Profile do
       end
       div do
         attributes_table_for profile do
-          rows :full_address, :general_info_tagline, :general_info_description,
-               :personal_preferences_sex, :date_preferences_description, :reviewed
+          Profile.moderated_params.each do |param|
+            if Profile.profanity_checked_params.include? param
+              row_with_profanity param, profile: profile
+            else
+              row param
+            end
+          end
+          row :reviewed
           row :possible_profanity do
             profile.profane?
           end

--- a/app/assets/javascripts/admin/controllers/profiles.js.coffee
+++ b/app/assets/javascripts/admin/controllers/profiles.js.coffee
@@ -6,4 +6,4 @@ $ ->
 $ ->
   $('.profile-inline-edit-activate').click ->
     $('.profile-inline-edit').toggleClass('profile-hide')
-    false
+    true

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -81,9 +81,21 @@
 }
 
 .profile-hide {
-  display: none;
+  display: none !important;
 }
 
 textarea.profile-inline-edit {
-  width: 76%;
+  width: 100% !important;
+}
+
+input.profile-inline-edit {
+  width: 100% !important;
+}
+
+select.profile-inline-edit {
+  width: 100% !important;
+}
+
+tr.profile-inline-edit, tr.profile-inline-edit > td:nth-child(2) {
+  width: 65%
 }

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -8,17 +8,101 @@ module ProfilesHelper
   end
 
   # for active admin table views
-  def select_row(param, type)
-    row param do
+  def select_row(param, type, options = {})
+    row param, options do
       select_title(type, profile.send(param))
     end
   end
 
-  def row_with_profanity(param)
-    row param do
+  def row_with_profanity(param, options = {})
+    profile ||= options[:profile]
+    options.delete :profile
+    row param, options do
       value = profile.send(param)
       words = Obscenity.offensive(value)
       highlight(value, words)
+    end
+  end
+
+  def profile_panel(name)
+    name = name.to_s
+    panel name.humanize, id: name do
+      render "admin/profile/#{name}"
+    end
+  end
+
+  def profile_panels(*names)
+    names.each do |name|
+      profile_panel name
+    end
+  end
+
+  def editable_form
+    form_for profile, url: admin_profile_path(profile) do |f|
+      yield f
+    end
+  end
+
+  def editable_row(name, options, &block)
+    profile ||= options[:profile]
+    with ||= options[:with]
+    f ||= options[:f]
+    type ||= options[:type]
+    if with == :profanity
+      row_with_profanity name, profile: profile, class: 'profile-inline-edit'
+    elsif with == :select
+      select_row name, type, class: 'profile-inline-edit'
+    elsif with.blank?
+      row name, class: 'profile-inline-edit'
+    else
+      row name, class: 'profile-inline-edit' do
+        value = profile.send(name)
+        "#{value} #{with.to_s}" unless value.blank?
+      end
+    end
+    row :"#{name}_edit", class: 'profile-hide profile-inline-edit' do
+      block.call(f, name, class: 'profile-hide profile-inline-edit')
+    end
+  end
+
+  def editable_text
+    Proc.new { |f, name, options| f.text_field name, options }
+  end
+
+  def editable_number(min = nil, max = nil)
+    Proc.new do |f, name, options|
+      options[:min] ||= min
+      options[:max] ||= max
+      f.number_field name, options
+    end
+  end
+
+  def editable_area
+    Proc.new do |f, name, options|
+      options[:rows] ||= 5
+      f.text_area name, options
+    end
+  end
+
+  def editable_select(type)
+    Proc.new { |f, name, options| f.select name, select_options(type), options }
+  end
+
+  def editable_checkbox
+    Proc.new do |f, name, options|
+      f.check_box name, options,'true', 'false'
+    end
+  end
+
+  def edit_link(anchor = nil)
+    span do
+      link_to 'Edit', "#{anchor || '#'}", class: 'profile-inline-edit-activate'
+    end
+  end
+
+  def edit_submit(f)
+    row 'Submit', class: 'profile-hide profile-inline-edit' do
+      f.submit class: 'button profile-hide profile-inline-edit'
     end
   end
 end

--- a/app/views/admin/profile/_address.html.arb
+++ b/app/views/admin/profile/_address.html.arb
@@ -1,0 +1,13 @@
+extend ProfilesHelper
+
+editable_form do |f|
+  edit_link '#address'
+  attributes_table_for profile do
+    editable_row :general_info_address_line_1, profile: profile, f: f, with: :profanity, &editable_text
+    editable_row :general_info_address_line_2, profile: profile, f: f, with: :profanity, &editable_text
+    editable_row :general_info_city, profile: profile, f: f, with: :profanity, &editable_text
+    editable_row :general_info_state, profile: profile, f: f, with: :profanity, &editable_text
+    editable_row :general_info_zip_code, profile: profile, f: f, with: :profanity, &editable_text
+    edit_submit f
+  end
+end

--- a/app/views/admin/profile/_approval_queue_navigation.html.arb
+++ b/app/views/admin/profile/_approval_queue_navigation.html.arb
@@ -1,0 +1,20 @@
+extend ProfilesHelper
+unless profile.reviewed?
+  div class: 'profile-grid' do
+    div class: 'profile-col-1-3' do
+      prev_profile = profile.prev_queued_for_approval
+      prev_title = profile.prev_queued_for_approval.nil? ? 'List' : 'Next'
+      next_profile = profile.next_queued_for_approval
+      next_title = profile.next_queued_for_approval.nil? ? 'List' : 'Prev'
+      span do
+        link_to next_title, admin_profile_path(next_profile), class: :button
+      end
+      unless prev_profile.nil? && next_profile.nil?
+        span do
+          link_to prev_title, admin_profile_path(prev_profile), class: :button
+        end
+      end
+    end
+  end
+  br
+end

--- a/app/views/admin/profile/_credits.html.arb
+++ b/app/views/admin/profile/_credits.html.arb
@@ -1,0 +1,1 @@
+'here be dragons'

--- a/app/views/admin/profile/_essays.html.arb
+++ b/app/views/admin/profile/_essays.html.arb
@@ -1,0 +1,12 @@
+extend ProfilesHelper
+
+editable_form do |f|
+  strong 'Marked words are possible profane' if profile.profane?
+  edit_link '#essays'
+  attributes_table_for profile do
+    editable_row :general_info_tagline, profile: profile, f: f, with: :profanity, &editable_text
+    editable_row :general_info_description, profile: profile, f: f, with: :profanity, &editable_area
+    editable_row :date_preferences_description, profile: profile, f: f, with: :profanity, &editable_area
+    edit_submit f
+  end
+end

--- a/app/views/admin/profile/_favorites_and_views.html.arb
+++ b/app/views/admin/profile/_favorites_and_views.html.arb
@@ -1,0 +1,1 @@
+'here be dragons'

--- a/app/views/admin/profile/_matches.html.arb
+++ b/app/views/admin/profile/_matches.html.arb
@@ -1,0 +1,15 @@
+extend ProfilesHelper
+
+editable_form do |f|
+  edit_link '#matches'
+  attributes_table_for profile do
+    editable_row :date_preferences_accepted_distance_do_care, profile: profile, f: f, &editable_checkbox
+    editable_row :date_preferences_accepted_distance, profile: profile, f: f, with: :miles, &editable_text
+    editable_row :date_preferences_smoker, profile: profile, f: f, with: :select,
+                 type: 'smoker', &(editable_select 'smoker')
+    editable_row :date_preferences_drinker, profile: profile, f: f, with: :select,
+                 type: 'drinker', &(editable_select 'drinker')
+    edit_submit f
+  end
+end
+

--- a/app/views/admin/profile/_offers.html.arb
+++ b/app/views/admin/profile/_offers.html.arb
@@ -1,0 +1,1 @@
+'here be dragons'

--- a/app/views/admin/profile/_other.html.arb
+++ b/app/views/admin/profile/_other.html.arb
@@ -1,0 +1,23 @@
+extend ProfilesHelper
+
+editable_form do |f|
+  edit_link '#other'
+  attributes_table_for profile do
+    # select_row :optional_info_religion, 'religion'
+    editable_row :optional_info_religion, profile: profile, f: f, with: :select,
+                 type: 'religion', &(editable_select 'religion')
+    # select_row :optional_info_ethnicity, 'ethnicity'
+    editable_row :optional_info_ethnicity, profile: profile, f: f, with: :select,
+                 type: 'ethnicity', &(editable_select 'ethnicity')
+    # select_row :optional_info_children, 'children'
+    editable_row :optional_info_children, profile: profile, f: f, with: :select,
+                 type: 'children', &(editable_select 'children')
+    # select_row :optional_info_smoker, 'me_smoker'
+    editable_row :optional_info_smoker, profile: profile, f: f, with: :select,
+                 type: 'me_smoker', &(editable_select 'me_smoker')
+    # select_row :optional_info_drinker, 'me_drinker'
+    editable_row :optional_info_drinker, profile: profile, f: f, with: :select,
+                 type: 'me_drinker', &(editable_select 'me_drinker')
+    edit_submit f
+  end
+end

--- a/app/views/admin/profile/_photo.html.arb
+++ b/app/views/admin/profile/_photo.html.arb
@@ -1,0 +1,6 @@
+div do
+  link_to 'View photos', admin_photos_path(scope: :pending, q: { album_user_id_eq: profile.user_id })
+end
+div do
+  link_to 'View avatars', admin_avatars_path(scope: :pending, q: { album_user_id_eq: profile.user_id })
+end

--- a/app/views/admin/profile/_physical_features.html.arb
+++ b/app/views/admin/profile/_physical_features.html.arb
@@ -1,0 +1,15 @@
+extend ProfilesHelper
+
+editable_form do |f|
+  edit_link '#physical_features'
+  attributes_table_for profile do
+    editable_row :optional_info_height, profile: profile, f: f, with: :cm, &(editable_number 130, 300)
+    editable_row :optional_info_body_type, profile: profile, f: f, with: :select,
+                 type: 'body_type', &(editable_select 'body_type')
+    editable_row :optional_info_hair_color, profile: profile, f: f, with: :select,
+                 type: 'hair_color', &(editable_select 'hair_color')
+    editable_row :optional_info_eye_color, profile: profile, f: f, with: :select,
+                 type: 'eye_color', &(editable_select 'eye_color')
+    edit_submit f
+  end
+end

--- a/app/views/admin/profile/_profile.html.arb
+++ b/app/views/admin/profile/_profile.html.arb
@@ -1,0 +1,19 @@
+extend ProfilesHelper
+
+div class: 'profile-grid' do
+  div class: 'profile-col-1-2' do
+    h3 do
+      span do
+        'Main Profile Info'
+      end
+      if profile.profane?
+        span 'Profane!', class: 'profile-label-danger'
+      end
+    end
+    profile_panels :profile_info, :address, :essays, :physical_features, :matches, :social, :other#, f: f
+  end
+  div class: 'profile-col-1-3' do
+    h3 'Profile Summary'
+    profile_panels :summary, :photo, :ranking, :credits, :favorites_and_views, :quotes, :offers, :settings#, f: f
+  end
+end

--- a/app/views/admin/profile/_profile_info.html.arb
+++ b/app/views/admin/profile/_profile_info.html.arb
@@ -1,0 +1,17 @@
+extend ProfilesHelper
+editable_form do |f|
+  edit_link '#profile_info'
+  attributes_table_for profile do
+    row :auto_user
+    editable_row :personal_preferences_sex, profile: profile, f: f, with: :select,
+                 type: 'sex', &(editable_select 'sex')
+    editable_row :personal_preferences_partners_sex, profile: profile, f: f, with: :select,
+                 type: 'sex', &(editable_select 'sex')
+    editable_row :optional_info_age, profile: profile, f: f, &(editable_number 16, 100)
+    editable_row :personal_preferences_relationship, profile: profile, f: f, with: :select,
+                 type: 'relationship', &(editable_select 'relationship')
+    editable_row :personal_preferences_want_relationship, profile: profile, f: f, with: :select,
+                 type: 'want_relationship', &(editable_select 'want_relationship')
+    edit_submit f
+  end
+end

--- a/app/views/admin/profile/_quotes.html.arb
+++ b/app/views/admin/profile/_quotes.html.arb
@@ -1,0 +1,1 @@
+'here be dragons'

--- a/app/views/admin/profile/_ranking.html.arb
+++ b/app/views/admin/profile/_ranking.html.arb
@@ -1,0 +1,1 @@
+'here be dragons'

--- a/app/views/admin/profile/_settings.html.arb
+++ b/app/views/admin/profile/_settings.html.arb
@@ -1,0 +1,6 @@
+div do
+  link_to 'Login as user', login_admin_user_path(profile.auto_user)
+end
+div do
+  link_to 'View Mailbox', '#'
+end

--- a/app/views/admin/profile/_social.html.arb
+++ b/app/views/admin/profile/_social.html.arb
@@ -1,0 +1,14 @@
+extend ProfilesHelper
+
+editable_form do |f|
+  edit_link '#social'
+  attributes_table_for profile do
+    editable_row :optional_info_education, profile: profile, f: f, with: :select,
+                 type: 'education', &(editable_select 'education')
+    editable_row :optional_info_occupation, profile: profile, f: f, with: :profanity, &editable_text
+    editable_row :optional_info_annual_income, profile: profile, f: f, with: '$ per year', &(editable_number 0)
+    editable_row :optional_info_net_worth, profile: profile, f: f, with: '$', &(editable_number 0)
+    edit_submit f
+  end
+end
+

--- a/app/views/admin/profile/_summary.html.arb
+++ b/app/views/admin/profile/_summary.html.arb
@@ -1,0 +1,27 @@
+extend ProfilesHelper
+div class: 'profile-grid' do
+  div class: 'profile-col-2-3' do
+    strong profile.auto_user.name
+    span "#{profile.optional_info_age || '??'} y/o"
+    br
+    div 'from'
+    strong profile.full_address
+    br
+    div 'Status:'
+    strong 'Active' unless profile.auto_user.blocked?
+    strong 'Suspended' if profile.auto_user.blocked?
+    br
+    div 'Last activity:'
+    activity = profile.auto_user.activities.last
+    if activity
+      strong "#{distance_of_time_in_words activity.created_at, Time.now} ago"
+    else
+      span '-'
+    end
+    br
+    span "Join date: #{profile.created_at.to_date}"
+  end
+  div class: 'profile-col-1-3' do
+    render 'profile/avatar', profile: profile
+  end
+end

--- a/app/views/me/profiles/edit.html.haml
+++ b/app/views/me/profiles/edit.html.haml
@@ -114,8 +114,6 @@
               %div
                 = f.select :optional_info_eye_color, select_options('eye_color')
                 = f.select :optional_info_hair_color, select_options('hair_color')
-              = f.label :address
-              %div= f.text_field :optional_info_address
               = f.label :children
               %div= f.select :optional_info_children, select_options('children')
               = f.label 'Smoking and drinking habits'

--- a/app/views/profiles/_profile.html.haml
+++ b/app/views/profiles/_profile.html.haml
@@ -64,6 +64,7 @@
     = render 'profiles/invite_link', user: profile.user
 
     = render 'profiles/send_gift_link', user: profile.user
+
     - if can? :manage, profile
       .row-fluid
         .span12

--- a/config/initializers/active_admin_template_handler.rb
+++ b/config/initializers/active_admin_template_handler.rb
@@ -1,0 +1,13 @@
+module ActiveAdmin
+  class CustomTemplateHandler
+    def call(template)
+      <<-END
+      Arbre::Context.new(assigns, self) {
+        #{ template.source }
+      }.to_s
+      END
+    end
+  end
+end
+
+ActionView::Template.register_template_handler :aa, ActiveAdmin::CustomTemplateHandler.new

--- a/config/sample_data.yml
+++ b/config/sample_data.yml
@@ -28,7 +28,6 @@
     optional_info_age: '39'
     optional_info_height: '191'
     optional_info_smoker: O
-    optional_info_address: ''
     optional_info_drinker: N
     optional_info_children: N
     optional_info_religion: C
@@ -68,7 +67,6 @@
     optional_info_age: '29'
     optional_info_height: '168'
     optional_info_smoker: N
-    optional_info_address: ''
     optional_info_drinker: N
     optional_info_children: N
     optional_info_religion: J
@@ -121,7 +119,6 @@
     optional_info_age: '39'
     optional_info_height: '163'
     optional_info_smoker: N
-    optional_info_address: ''
     optional_info_drinker: N
     optional_info_children: N
     optional_info_religion: C
@@ -162,7 +159,6 @@
     optional_info_age: '25'
     optional_info_height: '173'
     optional_info_smoker: N
-    optional_info_address: ''
     optional_info_drinker: N
     optional_info_children: C1
     optional_info_religion: C

--- a/db/migrate/20130806072339_remove_column_optional_info_address_from_profile.rb
+++ b/db/migrate/20130806072339_remove_column_optional_info_address_from_profile.rb
@@ -1,0 +1,5 @@
+class RemoveColumnOptionalInfoAddressFromProfile < ActiveRecord::Migration
+  def change
+    remove_column :profiles, :optional_info_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130802101254) do
+ActiveRecord::Schema.define(version: 20130806072339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,7 +186,6 @@ ActiveRecord::Schema.define(version: 20130802101254) do
     t.string   "optional_info_ethnicity"
     t.string   "optional_info_eye_color"
     t.string   "optional_info_hair_color"
-    t.string   "optional_info_address"
     t.string   "optional_info_children"
     t.string   "optional_info_smoker"
     t.string   "optional_info_drinker"

--- a/test/config/profile_loader_sample_data.yml
+++ b/test/config/profile_loader_sample_data.yml
@@ -22,7 +22,6 @@
     optional_info_age: '39'
     optional_info_height: '191'
     optional_info_smoker: O
-    optional_info_address: ''
     optional_info_drinker: N
     optional_info_children: N
     optional_info_religion: C

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -31,7 +31,6 @@ martins:
   optional_info_age: '39'
   optional_info_height: '191'
   optional_info_smoker: O
-  optional_info_address: ''
   optional_info_drinker: N
   optional_info_children: N
   optional_info_religion: C
@@ -75,7 +74,6 @@ mias:
   optional_info_age: '25'
   optional_info_height: '173'
   optional_info_smoker: N
-  optional_info_address: ''
   optional_info_drinker: N
   optional_info_children: C1
   optional_info_religion: C
@@ -131,7 +129,6 @@ sophias:
   optional_info_age: '39'
   optional_info_height: '163'
   optional_info_smoker: N
-  optional_info_address: ''
   optional_info_drinker: N
   optional_info_children: N
   optional_info_religion: C
@@ -174,7 +171,6 @@ roberts:
   optional_info_age: '29'
   optional_info_height: '168'
   optional_info_smoker: N
-  optional_info_address: ''
   optional_info_drinker: N
   optional_info_children: N
   optional_info_religion: J
@@ -219,7 +215,6 @@ rias:
   optional_info_ethnicity: W
   optional_info_eye_color: blue
   optional_info_hair_color: Blo
-  optional_info_address: ''
   optional_info_children: C1
   optional_info_smoker: N
   optional_info_drinker: N


### PR DESCRIPTION
Heroku url: http://payperdate-36-member-manage-ip.herokuapp.com

view profiles, internal ranking, credits pictures, delete, temporary suspend, etc

Page to view the complete details of particular user, including the users who was favorited, viewed, quoted, or offered, credits, settings preferences and so on
### Notes

Ranking, credits, favorites, etc. are not done yet, so there will be only placeholders for that. Once some of this features became done, it should fit in this placeholders.
Main feature of this issue is showing all available profile data in admin profile show and allow inline editing of that data.
### Checklist
- [x] Ensure all profile data is in profile view:
- [x] Add education to social panel.
- [x] Add panel other info: religion, ethnicity, children, smoker, drinker.
- [x] Add address panel
- [x] Make list of free form fields, which may contain profanity.
- [x] Add to it: occupation and address-related fields.
- [x] Make this list to be trigger for queueing for approval.
- [x] Make this list being checked with obscenity.
- [x] Extract panels to partials.
- [x] Add inline editing into another panels.
- [x] Add stub blocks: ranking, credits, favorites, views, quotes, offers, settings.
- [x] Add photo block stub for another issue to fill in.
- [x] Add delete account action.
