### PR TITLE
View Albums/Pictures of other Users

### DIFF
--- a/app/views/profiles/_profile.html.haml
+++ b/app/views/profiles/_profile.html.haml
@@ -63,6 +63,7 @@
       __#{profile.general_info_tagline}__
     = render 'profiles/invite_link', user: @user
     = render 'profiles/send_wink_link', user: @user
+    = link_to 'Albums', user_albums_path(@user), class: :btn
 
     - unless @user == current_user
       = render 'profiles/send_gift_link', user: @user


### PR DESCRIPTION
This must be working now, please check:
- When I uploaded some pictures of myself in My Album, this pictures are not visible to anyone accept me. 
- If the picture is declined, I receive a message.

When this pictures are approved by Admin, they become visible to other Users:
- [x] Add link on other user's profile to his Albums
- [x] display all the approved pictures in this Albums
