### PR TITLE
Edit profile by admin bug

### DIFF
--- a/lib/tasks/profile_loader.rb
+++ b/lib/tasks/profile_loader.rb
@@ -14,6 +14,7 @@ class ProfileLoader
     loaded_users = {}
     config.each do |user|
       u = create_user(user['name'])
+      u.profile.user = u
       u.profile.inner_dont_care_about_review_notifications = true
       u.profile.update!(user['profile'])
       u.profile.approve!

--- a/test/fixtures/profile_multiselects.yml
+++ b/test/fixtures/profile_multiselects.yml
@@ -294,6 +294,153 @@ mias_231:
   select_type: drinker
 
 
+sophias_pending_211:
+  profile: sophias_pending
+  name: personal_preferences_partners_sex
+  checked: true
+  value: M
+  select_type: sex
+
+sophias_pending_212:
+  profile: sophias_pending
+  name: personal_preferences_partners_sex
+  checked: false
+  value: F
+  select_type: sex
+
+sophias_pending_217:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: false
+  value: S
+  select_type: relationship
+
+sophias_pending_218:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: true
+  value: D
+  select_type: relationship
+
+sophias_pending_219:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: false
+  value: W
+  select_type: relationship
+
+sophias_pending_220:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: false
+  value: M
+  select_type: relationship
+
+sophias_pending_221:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: false
+  value: Se
+  select_type: relationship
+
+sophias_pending_222:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: false
+  value: Da
+  select_type: relationship
+
+sophias_pending_223:
+  profile: sophias_pending
+  name: personal_preferences_relationship
+  checked: false
+  value: C
+  select_type: relationship
+
+sophias_pending_213:
+  profile: sophias_pending
+  name: personal_preferences_want_relationship
+  checked: false
+  value: S
+  select_type: want_relationship
+
+sophias_pending_214:
+  profile: sophias_pending
+  name: personal_preferences_want_relationship
+  checked: true
+  value: D
+  select_type: want_relationship
+
+sophias_pending_215:
+  profile: sophias_pending
+  name: personal_preferences_want_relationship
+  checked: false
+  value: F
+  select_type: want_relationship
+
+sophias_pending_216:
+  profile: sophias_pending
+  name: personal_preferences_want_relationship
+  checked: false
+  value: A
+  select_type: want_relationship
+
+sophias_pending_224:
+  profile: sophias_pending
+  name: date_preferences_smoker
+  checked: false
+  value: S
+  select_type: smoker
+
+sophias_pending_225:
+  profile: sophias_pending
+  name: date_preferences_smoker
+  checked: true
+  value: N
+  select_type: smoker
+
+sophias_pending_226:
+  profile: sophias_pending
+  name: date_preferences_smoker
+  checked: false
+  value: O
+  select_type: smoker
+
+sophias_pending_227:
+  profile: sophias_pending
+  name: date_preferences_smoker
+  checked: false
+  value: D
+  select_type: smoker
+
+sophias_pending_228:
+  profile: sophias_pending
+  name: date_preferences_drinker
+  checked: false
+  value: D
+  select_type: drinker
+
+sophias_pending_229:
+  profile: sophias_pending
+  name: date_preferences_drinker
+  checked: true
+  value: N
+  select_type: drinker
+
+sophias_pending_230:
+  profile: sophias_pending
+  name: date_preferences_drinker
+  checked: false
+  value: ND
+  select_type: drinker
+
+sophias_pending_231:
+  profile: sophias_pending
+  name: date_preferences_drinker
+  checked: false
+  value: DC
+  select_type: drinker
+
 
 sophias_211:
   profile: sophias

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -141,6 +141,61 @@ sophias:
   optional_info_occupation: Transportation
   optional_info_annual_income:
 
+sophias_pending:
+  filled: true
+  reviewed: false
+  latitude: 25.75593
+  longitude: -80.2920819
+  general_info_city: Miami
+  general_info_state: Florida
+  general_info_tagline: Glass Half Full..
+  general_info_zip_code: '33155'
+  general_info_description: Here is a brief description of myself...mature,smart,sexy, cerebral,
+    passionate, loyal, caring, trustworthy,understanding young lady. I have had
+    a variety of life experiences and I like to live life to the fullest! I am not
+    a conventional person and I don't like to be placed in a box. I have always
+    been a more progressive thinker but I was placed in this world ahead of my time.
+    I have a very youthful appearance and although I will be flirty forty this year
+    I am often told by people that have nothing to gain that I look like I am in
+    my late twenties. I'll take that (smile) how about you?
+  general_info_address_line_1: 5920 SW 16th St
+  general_info_address_line_2: ''
+  personal_preferences_sex: F
+  # personal_preferences_partners_sex: M
+  # personal_preferences_relationship: D
+  # personal_preferences_want_relationship: D
+  # date_preferences_smoker: D
+  # date_preferences_drinker: DC
+  date_preferences_description: My ideal first date consists of inviting company, delectable food
+    and an amazing atmosphere. Sexy music ( think Beres Hammond, Greggory Issac)
+    and tropical drinks are a very welcome bonus (well maybe that should be the
+    second date) ha-ha. I want to feel like the lady that I am. I love a gentleman
+    (opening car doors, pulling out my chair);however, if that isn't your thing
+    I will be a soldier and open my own door (I may not agree to a second date)
+    :) Even though I am a forward thinker I like to indulge my sense of femininity
+    in this ambiguous world of political correctness when interacting with the opposite
+    sex (smile). In other words, by all means treat me like a lady. I am not looking
+    for payment for the first date (or any date for that matter). I just want to
+    show up,look beautiful,engage you in stimulating conversation, and have a great
+    time (and not pay for or go dutch for dinner...old school). If we click and
+    you decide to spoil me madly I will not object (smile).
+  date_preferences_accepted_distance: '50'
+  date_preferences_accepted_distance_do_care: 'true'
+  optional_info_birthday: 1975-11-19
+  optional_info_height: M6
+  optional_info_smoker: N
+  optional_info_drinker: N
+  optional_info_children: N
+  optional_info_religion: C
+  optional_info_body_type: Av
+  optional_info_education: S
+  optional_info_ethnicity: O
+  optional_info_eye_color: brown
+  optional_info_net_worth:
+  optional_info_hair_color: DBro
+  optional_info_occupation: Transportation
+  optional_info_annual_income:
+
 roberts:
   filled: true
   reviewed: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -66,7 +66,7 @@ sophia:
   nickname: 'sophia'
   encrypted_password: "$2a$10$C8mEde58Tg/X.n4XGqvTQOCV5/RM8NIjTAb3zZUbDS2Xn.7bZnuu2" #password
   confirmed_at: <%= Time.current %>
-  profile: sophias
+  profile: sophias_pending
   published_profile: sophias
 
 robert:

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -63,23 +63,17 @@ class ProfileTest < ActiveSupport::TestCase
     refute profile.valid?
   end
 
-  # This should go away. This fields are not integers now, but selects.
+  test 'should update only pending profile when admin changes published' do
+    published_profile = profiles(:sophias)
 
-  # test 'should be invalid if annual income lesser or equal 0' do
-  #   profile = profiles(:martins)
-  #   profile.optional_info_annual_income = -15
-  #   refute profile.valid?
-  # end
+    new_profile_info_tagline = 'Something intolerant'
+    old_profile_info_tagline = published_profile.general_info_tagline
 
-  # test 'should be invalid if annual net worth lesser or equal 0' do
-  #   profile = profiles(:martins)
-  #   profile.optional_info_net_worth = -15
-  #   refute profile.valid?
-  # end
+    published_profile.general_info_tagline = new_profile_info_tagline
+    published_profile.save!
 
-  # test 'should be invalid if annual height lesser or equal 0' do
-  #   profile = profiles(:martins)
-  #   profile.optional_info_height = -15
-  #   refute profile.valid?
-  # end
+    assert_equal new_profile_info_tagline, profiles(:sophias_pending).general_info_tagline
+    assert_equal old_profile_info_tagline, profiles(:sophias).general_info_tagline
+  end
+
 end

--- a/test/unit/profile_loader_test.rb
+++ b/test/unit/profile_loader_test.rb
@@ -15,4 +15,5 @@ class ProfileLoaderTest < ActiveSupport::TestCase
     user = User.find(@users['joe'].id)
     assert user.profile.filled?, 'user with profile should have filled profile'
   end
+
 end


### PR DESCRIPTION
This bug was detected in #53, but I suspect might have origin in earlier tasks:

When admin edits user's profile, user doesn't see those changes (his profile changes on admin panel, other users see changed profile, but user himself doesn't know about it). When User makes changes to his profile and saves it, profile updates on admin panel. So, all edits made by admin go nowhere.

Step-by-step screenshots:
Admin saves changes: http://dl.dropbox.com/u/110035603/Selection_131.png
Other users see updated profile: http://dl.dropbox.com/u/110035603/Selection_132.png
This what user sees: http://dl.dropbox.com/u/110035603/Selection_133.png
Then: http://dl.dropbox.com/u/110035603/Selection_134.png

I see several issues in here: 
- [x] user has to know that changes where made to his profile by someone else, 
- [x] user has to know how his current approved profile looks (already have), 
- [x] when admin makes changes to user's profile, changed fields must be updated in pending profile too
- [ ] hopefully, all three above will help us avoid the situation http://dl.dropbox.com/u/110035603/Selection_134.png
