### PR TITLE
Bug with Profile and avatar

### DIFF
--- a/app/views/admin/user/_avatar.html.erb
+++ b/app/views/admin/user/_avatar.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag user.avatar_url(:avatar, false) %>
+<%= image_tag user.avatar_url(:avatar, true) %>


### PR DESCRIPTION
Heroku Url: http://payperdate-78-bug-with-alexey.herokuapp.com/

User added picture to her profile: http://dl.dropbox.com/u/110035603/Selection_129.png
This picture was declined and was not visible to other users: http://dl.dropbox.com/u/110035603/Selection_128.png
Then this User was blocked. 
Then admin decided to unblock her, went to her profile: http://dl.dropbox.com/u/110035603/Selection_130.png
And here I see her profile with the avatar that was not approved!: http://dl.dropbox.com/u/110035603/Selection_127.png.

Please investigate and fix it.
