### PR TITLE
DO NOT PERMIT for blocked or deleted user to get access to the site by password reset!

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,27 @@
 class Users::PasswordsController < Devise::PasswordsController
   # pulled from original devise code
   # and patched to not sign_in if state is not active
+  # and deleted_state is not none
+  # and to restrict password reset for deleted users at all
+
+  # POST /resource/password
+  def create
+    found = resource_class.find_for_database_authentication(resource_params)
+    if !found || found.deleted_state == 'none'
+      self.resource = resource_class.send_reset_password_instructions(resource_params)
+
+      if successfully_sent?(resource)
+        respond_with({}, :location => after_sending_reset_password_instructions_path_for(resource_name))
+      else
+        respond_with(resource)
+      end
+    else
+      puts 'bga'
+      set_flash_message(:alert, :deleted)
+      respond_with found, location: new_user_password_path
+    end
+  end
+
   # PUT /resource/password
   def update
     self.resource = resource_class.reset_password_by_token(resource_params)
@@ -10,7 +31,7 @@ class Users::PasswordsController < Devise::PasswordsController
       flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
       set_flash_message(:notice, flash_message) if is_navigational_format?
       # here goes change
-      sign_in(resource_name, resource) if resource.active?
+      sign_in(resource_name, resource) if resource.active? and resource.deleted_state == 'none'
       respond_with resource, :location => after_resetting_password_path_for(resource)
     else
       respond_with resource

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -31,6 +31,7 @@ en:
       updated: 'Your password was changed successfully. You are now signed in.'
       updated_not_active: 'Your password was changed successfully.'
       send_paranoid_instructions: "If your e-mail exists on our database, you will receive a password recovery link on your e-mail"
+      deleted: 'You cannot reset password. User with this email was suspended / deleted.'
     confirmations:
       send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'
       send_paranoid_instructions: 'If your e-mail exists on our database, you will receive an email with instructions about how to confirm your account in a few minutes.'


### PR DESCRIPTION
Heroku url: http://payperdate-87-do-not-p-alexey.herokuapp.com/

the same problem once again:
Mia deleted herself, then she made reset password and got access to the site http://dl.dropbox.com/u/110035603/Selection_170.png
she was able to perform all actions, ex: she sent an invitation to Sophia http://dl.dropbox.com/u/110035603/Selection_171.png
